### PR TITLE
Honor synchronized output and cursor visibility

### DIFF
--- a/crates/gpui_ghostty_terminal/src/session.rs
+++ b/crates/gpui_ghostty_terminal/src/session.rs
@@ -6,6 +6,8 @@ pub struct TerminalSession {
     config: TerminalConfig,
     terminal: Terminal,
     bracketed_paste_enabled: bool,
+    cursor_visible: bool,
+    synchronized_output_active: bool,
     mouse_x10_enabled: bool,
     mouse_button_event_enabled: bool,
     mouse_any_event_enabled: bool,
@@ -25,6 +27,8 @@ impl TerminalSession {
             config,
             terminal,
             bracketed_paste_enabled: false,
+            cursor_visible: true,
+            synchronized_output_active: false,
             mouse_x10_enabled: false,
             mouse_button_event_enabled: false,
             mouse_any_event_enabled: false,
@@ -55,6 +59,14 @@ impl TerminalSession {
 
     pub fn bracketed_paste_enabled(&self) -> bool {
         self.bracketed_paste_enabled
+    }
+
+    pub fn cursor_visible(&self) -> bool {
+        self.cursor_visible
+    }
+
+    pub fn synchronized_output_active(&self) -> bool {
+        self.synchronized_output_active
     }
 
     pub fn mouse_reporting_enabled(&self) -> bool {
@@ -139,7 +151,9 @@ impl TerminalSession {
                     let enabled = b == b'h';
                     for ps in nums {
                         match ps {
+                            25 => self.cursor_visible = enabled,
                             2004 => self.bracketed_paste_enabled = enabled,
+                            2026 => self.synchronized_output_active = enabled,
                             1000 => self.mouse_x10_enabled = enabled,
                             1002 => self.mouse_button_event_enabled = enabled,
                             1003 => self.mouse_any_event_enabled = enabled,

--- a/crates/gpui_ghostty_terminal/src/tests.rs
+++ b/crates/gpui_ghostty_terminal/src/tests.rs
@@ -95,6 +95,63 @@ fn tracks_bracketed_paste_mode_from_output() {
 }
 
 #[test]
+fn tracks_cursor_visibility_from_output() {
+    let mut session = TerminalSession::new(TerminalConfig::default()).unwrap();
+    assert!(session.cursor_visible());
+
+    session.feed(b"\x1b[?25l").unwrap();
+    assert!(!session.cursor_visible());
+
+    session.feed(b"\x1b[?25h").unwrap();
+    assert!(session.cursor_visible());
+}
+
+#[test]
+fn tracks_cursor_visibility_across_chunk_boundaries() {
+    let mut session = TerminalSession::new(TerminalConfig::default()).unwrap();
+    session.feed(b"\x1b[?2").unwrap();
+    assert!(session.cursor_visible());
+
+    session.feed(b"5l").unwrap();
+    assert!(!session.cursor_visible());
+
+    session.feed(b"\x1b[?25").unwrap();
+    assert!(!session.cursor_visible());
+
+    session.feed(b"h").unwrap();
+    assert!(session.cursor_visible());
+}
+
+#[test]
+fn tracks_synchronized_output_mode_from_output() {
+    let mut session = TerminalSession::new(TerminalConfig::default()).unwrap();
+    assert!(!session.synchronized_output_active());
+
+    session.feed(b"\x1b[?2026h").unwrap();
+    assert!(session.synchronized_output_active());
+
+    session.feed(b"\x1b[?2026l").unwrap();
+    assert!(!session.synchronized_output_active());
+}
+
+#[test]
+fn tracks_synchronized_output_mode_across_chunk_boundaries() {
+    let mut session = TerminalSession::new(TerminalConfig::default()).unwrap();
+
+    session.feed(b"\x1b[?20").unwrap();
+    assert!(!session.synchronized_output_active());
+
+    session.feed(b"26h").unwrap();
+    assert!(session.synchronized_output_active());
+
+    session.feed(b"\x1b[?202").unwrap();
+    assert!(session.synchronized_output_active());
+
+    session.feed(b"6l").unwrap();
+    assert!(!session.synchronized_output_active());
+}
+
+#[test]
 fn tracks_mouse_reporting_mode_from_output() {
     let mut session = TerminalSession::new(TerminalConfig::default()).unwrap();
     assert!(!session.mouse_reporting_enabled());

--- a/crates/gpui_ghostty_terminal/src/view/mod.rs
+++ b/crates/gpui_ghostty_terminal/src/view/mod.rs
@@ -244,6 +244,16 @@ impl ByteSelection {
 }
 
 impl TerminalView {
+    fn has_synchronized_output_mode_change(bytes: &[u8]) -> bool {
+        bytes.windows(8).any(|window| {
+            matches!(
+                window,
+                [0x1b, b'[', b'?', b'2', b'0', b'2', b'6', b'h']
+                    | [0x1b, b'[', b'?', b'2', b'0', b'2', b'6', b'l']
+            )
+        })
+    }
+
     pub fn new(session: TerminalSession, focus_handle: FocusHandle) -> Self {
         Self {
             session,
@@ -1931,10 +1941,11 @@ impl Element for TerminalTextElement {
 
         let cursor = {
             let view = self.view.read(cx);
-            view.focus_handle
-                .is_focused(window)
-                .then(|| view.session.cursor_position())
-                .flatten()
+            if view.focus_handle.is_focused(window) && view.session.cursor_visible() {
+                view.session.cursor_position()
+            } else {
+                None
+            }
         }
         .and_then(|(col, row)| {
             let background = { self.view.read(cx).session.default_background() };
@@ -2041,12 +2052,22 @@ impl Render for TerminalView {
 
         if !self.pending_output.is_empty() {
             let bytes = std::mem::take(&mut self.pending_output);
+            let sync_before = self.session.synchronized_output_active();
+            let touched_sync_mode = Self::has_synchronized_output_mode_change(&bytes);
             self.feed_output_bytes_to_session(&bytes);
             self.apply_side_effects(cx);
-            self.reconcile_dirty_viewport_after_output();
+            let sync_after = self.session.synchronized_output_active();
+
+            if sync_after {
+                self.pending_refresh = true;
+            } else if sync_before || touched_sync_mode {
+                self.pending_refresh = true;
+            } else {
+                self.reconcile_dirty_viewport_after_output();
+            }
         }
 
-        if self.pending_refresh {
+        if self.pending_refresh && !self.session.synchronized_output_active() {
             self.refresh_viewport();
             self.pending_refresh = false;
         }

--- a/crates/gpui_ghostty_terminal/src/view/mod.rs
+++ b/crates/gpui_ghostty_terminal/src/view/mod.rs
@@ -684,8 +684,12 @@ impl TerminalView {
 
     pub fn feed_output_bytes(&mut self, bytes: &[u8], cx: &mut Context<Self>) {
         self.feed_output_bytes_to_session(bytes);
-        self.refresh_viewport();
         self.apply_side_effects(cx);
+        if self.session.synchronized_output_active() {
+            self.pending_refresh = true;
+        } else {
+            self.refresh_viewport();
+        }
         cx.notify();
     }
 
@@ -702,7 +706,10 @@ impl TerminalView {
             let pending = std::mem::take(&mut self.pending_output);
             self.feed_output_bytes_to_session(&pending);
             self.apply_side_effects(cx);
-            self.reconcile_dirty_viewport_after_output();
+            // Large output burst overflowed the pending buffer; dirty-row
+            // reconciliation may not cover every affected row, so request a
+            // full viewport refresh to avoid stale content.
+            self.pending_refresh = true;
         }
 
         if bytes.len() > MAX_PENDING_OUTPUT_BYTES {
@@ -713,7 +720,9 @@ impl TerminalView {
                 offset = end;
             }
             self.apply_side_effects(cx);
-            self.reconcile_dirty_viewport_after_output();
+            // Multiple large chunks were fed sequentially; the VT's dirty set
+            // may only reflect the last chunk. Force a full refresh.
+            self.pending_refresh = true;
             cx.notify();
             return;
         }
@@ -2050,7 +2059,8 @@ impl Render for TerminalView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         ensure_key_bindings(cx);
 
-        if !self.pending_output.is_empty() {
+        let had_pending_output = !self.pending_output.is_empty();
+        if had_pending_output {
             let bytes = std::mem::take(&mut self.pending_output);
             let sync_before = self.session.synchronized_output_active();
             let touched_sync_mode = Self::has_synchronized_output_mode_change(&bytes);
@@ -2067,9 +2077,14 @@ impl Render for TerminalView {
             }
         }
 
-        if self.pending_refresh && !self.session.synchronized_output_active() {
-            self.refresh_viewport();
-            self.pending_refresh = false;
+        if self.pending_refresh {
+            // Only defer refresh while synchronized output is active AND
+            // the refresh was triggered by PTY output.  User-driven
+            // refreshes (resize, scrollback) must never be blocked.
+            if !self.session.synchronized_output_active() || !had_pending_output {
+                self.refresh_viewport();
+                self.pending_refresh = false;
+            }
         }
 
         if self.session.window_title_updates_enabled() {


### PR DESCRIPTION
## Summary
- track cursor visibility and synchronized-output mode from terminal output
- hide the cursor when the terminal requests it
- defer viewport refreshes until synchronized-output transactions close to avoid partial redraws

## Testing
- ZIG=/Users/zakimanian/code/CEO/.context/zig/zig cargo test -p gpui_ghostty_terminal